### PR TITLE
#bug 79: Stars dropdown is not closed automatically after clicking on…

### DIFF
--- a/src/client/components/ranking-bar/index.jsx
+++ b/src/client/components/ranking-bar/index.jsx
@@ -52,7 +52,6 @@ export class RankingBar extends React.Component {
                         style={{ width:70, border: 0 }}
                         item
                         text="Stars"
-                        simple
                         icon="caret down"
                     >
                         <Dropdown.Menu>


### PR DESCRIPTION
… stars [5 -> 1] filter

This bug is connected with Semantic UI bug in Dropdown element if parameter "simple" used. By removing it we get expected Dropdown close, but Dropdown open on hover doesn't work anymore